### PR TITLE
Fix typos and broken links. Adds 4Site SOP doc

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -60,6 +60,10 @@ export const navigation = [
         title: 'Upgrading from engrid-common',
         href: '/docs/v2/upgrading-from-engrid-common',
       },
+      {
+        title: '4Site SOP: ENgrid Development & Code Deployment',
+        href: '/docs/v2/4site-sop-engrid-development-code-deployment',
+      },
     ],
   },
   {

--- a/src/pages/docs/v2/4site-sop-engrid-development-code-deployment.md
+++ b/src/pages/docs/v2/4site-sop-engrid-development-code-deployment.md
@@ -1,0 +1,63 @@
+---
+title: "4Site SOP: ENgrid Development & Code Deployment"
+---
+
+## **1\. Objective**
+
+To ensure the stability of live client pages, prevent version regression, and maintain quality assurance across all ENgrid Engaging Networks deployments. This process specifically addresses protocols for pushing code to active accounts and managing front-end changes that impact multiple clients.
+
+## **2\. Authorized Personnel**
+
+Strict access control applies to active Engaging Networks accounts.
+
+- **Approved Deployers:** Only **Fernando, Michael T., and Bryan** are authorized to push code live to _active_ Engaging Networks accounts.
+- **Other Developers:**
+  - May NOT push code to active accounts without explicit, case-by-case authorization.
+  - Authorization can only be granted by **Fernando** or **Michael T.**
+  - Even with authorization, Junior Developers must not deploy in isolation (see _Communication Protocols_).
+- **Dev Support POC:** Every developer task must have a defined **Dev Support Point of Contact** listed in the Productive task. This POC must be either Fernando, Bryan, or Michael T.
+
+## **3\. Pre-Deployment & Development Protocols**
+
+### **A. Version Control & Asset Management**
+
+- **Check ENgrid Versions:** Before committing code or building files, developers must ensure their local environment matches the client's current live ENgrid version.
+  - _Risk Mitigation:_ This prevents overwriting a newer live version with an older local build (a known issue that causes regression).
+- **Front-End Multi-Client Updates:**
+  - Any front-end work (CSS/JS) that touches multiple clients (e.g., updates to the **Promo Plugin**) must undergo a mandatory Code Review & QA by the **Director of Development (Fernando)** before implementation.
+  - _Note:_ This is to ensure CSS updates intended for one platform (e.g., EveryAction) do not negatively impact the visual layout of Engaging Networks forms.
+
+### **B. Communication Protocols**
+
+- **No Siloed Deployments:** Communication regarding pushing code live must **never** happen via Slack Direct Message.
+- **Public Slack Channels:** All requests, approvals, and confirmations regarding deployment must occur in the public project Slack channel or the dedicated ENgrid channel.
+  - _Reasoning:_ This ensures the wider team has visibility on changes, allowing others to flag potential conflicts or errors immediately.
+- **Productive as source of record:** The Productive task must also be updated to confirm explicit consent for deployment.
+
+## **4\. Deployment Procedure**
+
+### **Step 1: Verification**
+
+- **Verify Client Account:** Ensure you are logged into the correct Engaging Networks server (e.g., verify US vs. Canada accounts).
+- **Verify Local Assets:** Double-check that the file folder open on your machine matches the client you are uploading to.
+
+### **Step 2: Deployment**
+
+- Ensure you are on the right Engaging Networks folder (usually called “Ω 4Site \- ENgrid” or “Ω1. 4Site Live \- ENgrid Page Template and Components” \- [ref](https://engrid.4sitestudios.com/docs/v2/en-account-buildout#en-uploaded-assets))
+- Upload the assets to the verified Engaging Networks account.
+
+### **Step 3: Mandatory Post-Deployment Testing**
+
+**All deployments to active accounts require a Live Donation Test.**
+
+1. **Clear Cache/Cookies:** Ensure you are viewing the most recent version of the page.
+2. **Visual Verification:** Navigate to the client’s main donation page to ensure assets are loading correctly and layout integrity is maintained.
+3. **Live Transaction:** Perform a **real** (live) donation.
+   - **Location Requirement:** The donation must be made from the **United States** (to ensure proper handling of state/region codes and address validation).
+   - _Why Live?_ Test donations often miss specific CSS issues (such as a hidden submit button) or gateway rejections that only occur in live environments.
+4. **Refund:** Immediately request a refund for the live donation using the [live donation testing refund form](https://docs.google.com/forms/d/1IlnKH87YDPTkwsac9szuqNSALbMf0YwteDBSTwomai8/viewform)
+
+## **5\. Emergency & Rushed Timelines**
+
+- **No Exceptions:** Even during high-pressure periods (e.g., End of Year, Giving Tuesday, or last-minute client requests), **steps 1–3 of the Deployment Procedure are mandatory.**
+- Rushed timelines often lead to errors (e.g., cookie suppression bugs, version mismatches). If a timeline does not allow for this process, the deployment must be flagged to the Project Manager and/or Director of Development immediately.

--- a/src/pages/docs/v2/contributing-to-engrid.md
+++ b/src/pages/docs/v2/contributing-to-engrid.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing to ENgrid Scripts
-description: How to contribute how to the ENgrid Scripts library
+description: How to contribute to the ENgrid Scripts library
 ---
 
 ## What is ENgrid Scripts?

--- a/src/pages/docs/v2/creating-an-engrid-theme.md
+++ b/src/pages/docs/v2/creating-an-engrid-theme.md
@@ -94,7 +94,7 @@ Now it’s time to create a Donation page!
 After you’ve finished creating your page, we now need to get the page ENgrid-ready. There are two ways to do this:
 
 - Manually, creating each necessary section as you go
-- If you have the TamperMonkey extension installed on Chrome, you can [grab this script](https://github.com/4site-interactive-studios/bryans-tampermonkey-scripts/blob/main/ENgrid%20-%20Populate%2018%20Semantic%20Sections%20into%20Advanced%20Row.user.js) for use for setting up your page. The bryans-tampermonkey-scripts repository is private; access is restricted to 4Site staff only.
+- If you have the TamperMonkey extension installed on Chrome, you can [grab this script](https://github.com/4site-interactive-studios/bryans-tampermonkey-scripts/blob/main/ENgrid%20-%20Populate%2018%20Semantic%20Sections%20into%20Advanced%20Row.user.js) for use for setting up your page. `bryans-tampermonkey-scripts` repository is private; access is restricted to 4Site staff only.
 
 In order to set up the structure for your page:
 

--- a/src/pages/docs/v2/creating-an-engrid-theme.md
+++ b/src/pages/docs/v2/creating-an-engrid-theme.md
@@ -86,7 +86,7 @@ Now it’s time to create a Donation page!
 2. In the **Home/Ω3. 4Site Development - Code Development** folder, click on **+New Page**.
 3. Select **Donation page**, then click **Next**.
 4. Enter a name for your page in the **Name** field.
-5. In the **Template** dropdown, select the **4Site Page Template - Center Left 1 Colum** template which you created earlier.
+3. In the **Template** dropdown, select the **4Site Page Template - Center Left 1 Column** template which you created earlier.
 6. Click on **Next** - this will take you to the **Donation Settings** for your page.
 7. Select the Test version of the payment gateway being used by the client. When you are ready for production, you can change this to the Live version.
 8. Click on **Next** - this will take you to the **Notification Settings**. Nothing needs to be set here for the time being, so just click on **Next** again. Your page has been created!
@@ -94,7 +94,7 @@ Now it’s time to create a Donation page!
 After you’ve finished creating your page, we now need to get the page ENgrid-ready. There are two ways to do this:
 
 - Manually, creating each necessary section as you go
-- If you have the TamperMonkey extension installed on Chrome, you can [grab this script](https://github.com/4site-interactive-studios/bryans-tampermonkey-scripts/blob/main/ENgrid%20-%20Populate%2018%20Semantic%20Sections%20into%20Advanced%20Row.user.js) for use for setting up your page.
+- If you have the TamperMonkey extension installed on Chrome, you can [grab this script](https://github.com/4site-interactive-studios/bryans-tampermonkey-scripts/blob/main/ENgrid%20-%20Populate%2018%20Semantic%20Sections%20into%20Advanced%20Row.user.js) for use for setting up your page. The bryans-tampermonkey-scripts repository is private; access is restricted to 4Site staff only.
 
 In order to set up the structure for your page:
 

--- a/src/pages/docs/v2/developing-with-engrid.md
+++ b/src/pages/docs/v2/developing-with-engrid.md
@@ -157,7 +157,7 @@ You can combine these parameters to completely disable ENgrid when troubleshooti
 
 ### Variables Reference
 
-- [https://raw.githubusercontent.com/4site-interactive-studios/engrid/main/packages/styles/src/\_engrid-variables.scss](https://raw.githubusercontent.com/4site-interactive-studios/engrid/main/packages/styles/src/_engrid-variables.scss)
+- You can find style variable references in the [Styles Source Folder](https://github.com/4site-interactive-studios/engrid/tree/main/packages/styles/src).
 
 ### Advanced "Row"
 

--- a/src/pages/docs/v2/donation-receipting.md
+++ b/src/pages/docs/v2/donation-receipting.md
@@ -10,7 +10,7 @@ description: Learn the essentials of managing fundraising receipts with ENgrid a
 
 [https://e-activist.com/index.html#receipt](https://e-activist.com/index.html#receipt)
 
-There are seven types of receipts you can create. but OC only makes use of
+There are seven types of receipts you can create, but OC only makes use of
 
 * **Original Receipt** - For when someone makes a gift. [More information here](https://www.engagingnetworks.support/knowledge-base/fundraising-receipt/)
 * **Replacement Receipt** - A replacement of an Original Receipt. [More information here](https://www.engagingnetworks.support/knowledge-base/gadgets-single-donations/) under the “Issuing a replacement receipt” heading.
@@ -69,9 +69,9 @@ Screencast of resending a receipt: [https://d.pr/v/ucWHNB](https://d.pr/v/ucWHNB
 Received email for **"Replacement Receipt"**: [https://d.pr/i/b0dCkk](https://d.pr/i/b0dCkk)
 
 
-### Recurring Gift Recepting 
+### Recurring Gift Receipting 
 
-Note an option. According to EN support 
+Not an option. According to EN support 
 >We don't issue receipts for recurring donations because they are one part gift of a whole.
 
 

--- a/src/pages/docs/v2/engrid-page-template-example.md
+++ b/src/pages/docs/v2/engrid-page-template-example.md
@@ -1,9 +1,9 @@
 ---
-title: ENgrid and Page BuilderTemplate Structure and Optimization
-description: Learn about the intricacies Engaging Network's Page Builder and ENgrid templates. This guide provides a detailed breakdown of template structures, optimization techniques, and best practices to supercharge your page's performance and design.
+title: ENgrid and Page Builder Template Structure and Optimization
+description: Learn about the intricacies of Engaging Network's Page Builder and ENgrid templates. This guide provides a detailed breakdown of template structures, optimization techniques, and best practices to supercharge your page's performance and design.
 ---
 
-Engaging Network's Page Buidler Templates are the HTML wrapper for your pages.
+Engaging Network's Page Builder Templates are the HTML wrapper for your pages.
 
 To view your templates, and to edit and create new ones, go to Pages > Components > Templates.
 
@@ -29,11 +29,11 @@ Usually copied directly from organizational website
 
 #### Meta Tags
 
-    These tags are here to provide Page Template level defaults for social sharing that can then be overwritten when Social Sharing Settings are configured on an individual page. This was extensively tested, no tags more / no tags less should be used. See: [GitHub Issue #12](https://github.com/4site-interactive-studios/en-wishlist/issues/12)
+These tags are here to provide Page Template level defaults for social sharing that can then be overwritten when Social Sharing Settings are configured on an individual page. This was extensively tested, no tags more / no tags less should be used. See: [GitHub Issue #12](https://github.com/4site-interactive-studios/en-wishlist/issues/12)
 
 ```javascript
 <!-- Sharing Meta Tags Used by Facebook-->
-<title>${page~title} | TBD-ORG-NAME - TBD-ORG-TAGLINE>/title>
+<title>${page~title} | TBD-ORG-NAME - TBD-ORG-TAGLINE</title>
 <meta property="og:type" content="website">
 <meta property="fb:app_id" content="1234567890"><!-- Optional -->
 

--- a/src/pages/docs/v2/engrid-template-scaffolding-checklist.md
+++ b/src/pages/docs/v2/engrid-template-scaffolding-checklist.md
@@ -87,6 +87,7 @@ At this point you have an empty ENGrid donation page in the new org with the rig
 - [ ] Install the TamperMonkey browser extension in Chrome (if you don't already have it).
 - [ ] Install the ENGrid TamperMonkey script:
   - [ ] Direct link: [ENgrid - Populate 18 Semantic Sections into Advanced Row.user.js](https://github.com/4site-interactive-studios/bryans-tampermonkey-scripts/blob/main/ENgrid%20-%20Populate%2018%20Semantic%20Sections%20into%20Advanced%20Row.user.js)
+    Note: This repository is private. You must be logged into GitHub and have 4Site staff access to view it.
   - [ ] Click **Raw** to view the script source.
   - [ ] TamperMonkey should automatically prompt you to install it. Approve the installation.
   - [ ] Alternatively, you can find this script referenced in the "Creating an ENGrid Theme" documentation under **Core Concepts**.
@@ -260,6 +261,7 @@ If the two pages look the same, the scaffold is correct.
    - Add a test gateway under Donation Settings.
    - Save + reopen.
 5. Install TamperMonkey and the ENGrid script from [GitHub](https://github.com/4site-interactive-studios/bryans-tampermonkey-scripts/blob/main/ENgrid%20-%20Populate%2018%20Semantic%20Sections%20into%20Advanced%20Row.user.js).
+   - Note: This repository is private. You must be logged into GitHub and have 4Site staff access to view it.
 6. In the new Donation Page:
    - Delete default row.
    - Add Advanced Row / Custom Layout.

--- a/src/pages/docs/v2/training.md
+++ b/src/pages/docs/v2/training.md
@@ -68,7 +68,7 @@ Let's run through the whole process of making and testing a change to your ENgri
 ## Upstream ENgrid Scripts Changes
 
 * Clone the ENgrid Scripts repository [https://github.com/4site-interactive-studios/engrid/](https://github.com/4site-interactive-studios/engrid/) and make a new branch.
-* Update your "/src/index.ts" and and "/src/sass/main.scss" to point to the local assets instead of the NPM assets.
+* Update your "/src/index.ts" and "/src/sass/main.scss" to point to the local assets instead of the NPM assets.
 * Run "npm run watch" in your engrid-scripts directory, and "npm run start" in your theme directory.
 * Make any necessary changes
 * Push your code to Github and open a Pull Request, tagging Fernando as a reviewer. 

--- a/src/pages/docs/v2/upsells.md
+++ b/src/pages/docs/v2/upsells.md
@@ -111,7 +111,7 @@ Some options allows variables, that will get replaced by dynamic values:
 
 ## Donation: Upsell Checkbox
 
-These pseudo checkboxes mirror the markup of Engaging Networks checkboxes so they get styled the same, but their values are never saved or submitted as part of the form submission. If the pseudo checkbox contains the correct special `value` and `name`, when selected or unselected, this will cause the Donation Frequency to change from one-time to the defined recurrancy, or vice versa. In the example below `MONTHLY` is set as the value and name is set as `engrid.recurrfreq` which will cause the Recurring Frequency field to toggle between One Time and Monthly when the checkbox is toggled.
+These pseudo checkboxes mirror the markup of Engaging Networks checkboxes so they get styled the same, but their values are never saved or submitted as part of the form submission. If the pseudo checkbox contains the correct special `value` and `name`, when selected or unselected, this will cause the Donation Frequency to change from one-time to the defined recurrency, or vice versa. In the example below `MONTHLY` is set as the value and name is set as `engrid.recurrfreq` which will cause the Recurring Frequency field to toggle between One Time and Monthly when the checkbox is toggled.
 
 These checkboxes can be combined with the Utility classes that hide/show a component based on giving frequency.
 

--- a/src/pages/docs/v2/visualizing-engrid-grids.md
+++ b/src/pages/docs/v2/visualizing-engrid-grids.md
@@ -28,7 +28,7 @@ description: Explore ENgrid's capabilities through detailed visualizations, unde
 | Signup page                | [https://act.ran.org/page/14325/subscribe/1](https://act.ran.org/page/14325/subscribe/1)                                   |
 | Donate page                | [https://act.ran.org/page/14297/donate/1](https://act.ran.org/page/14297/donate/1)                                         |
 | Donate w/ in-honor         | [https://act.ran.org/page/14297/donate/1?transaction.inmem=Y](https://act.ran.org/page/14297/donate/1?transaction.inmem=Y) |
-| Email to Target Page       | [https://act.ran.org/page/14327/action/1](https://act.ran.org/page/14327/action/1)                                         |
+| Email to Target Page       | [https://act.ran.org/page/55579/subscribe/1](https://act.ran.org/page/55579/subscribe/1)                                         |
 | Tweet to Target Pages      | [https://act.ran.org/page/14328/tweet/1](https://act.ran.org/page/14328/tweet/1)                                           |
 | Event Pages                | [https://act.ran.org/page/14333/event/1](https://act.ran.org/page/14333/event/1)                                           |
 | Supporter Hub (Not tested) | [https://act.ran.org/page/14331/hub/1](https://act.ran.org/page/14331/hub/1)                                               |

--- a/src/pages/docs/v2/visualizing-engrid-grids.md
+++ b/src/pages/docs/v2/visualizing-engrid-grids.md
@@ -28,7 +28,7 @@ description: Explore ENgrid's capabilities through detailed visualizations, unde
 | Signup page                | [https://act.ran.org/page/14325/subscribe/1](https://act.ran.org/page/14325/subscribe/1)                                   |
 | Donate page                | [https://act.ran.org/page/14297/donate/1](https://act.ran.org/page/14297/donate/1)                                         |
 | Donate w/ in-honor         | [https://act.ran.org/page/14297/donate/1?transaction.inmem=Y](https://act.ran.org/page/14297/donate/1?transaction.inmem=Y) |
-| Email to Target Page       | [https://act.ran.org/page/55579/subscribe/1](https://act.ran.org/page/55579/subscribe/1)                                         |
+| Email to Target Page       | [https://act.ran.org/page/59476/action/1](https://act.ran.org/page/59476/action/1)                                         |
 | Tweet to Target Pages      | [https://act.ran.org/page/14328/tweet/1](https://act.ran.org/page/14328/tweet/1)                                           |
 | Event Pages                | [https://act.ran.org/page/14333/event/1](https://act.ran.org/page/14333/event/1)                                           |
 | Supporter Hub (Not tested) | [https://act.ran.org/page/14331/hub/1](https://act.ran.org/page/14331/hub/1)                                               |

--- a/src/pages/docs/v2/what-is-engrid-and-client-theme.md
+++ b/src/pages/docs/v2/what-is-engrid-and-client-theme.md
@@ -7,11 +7,11 @@ As you get started working with ENgrid, it is good to discuss what a "Client The
 
 ## What is a "Theme"?
 
-A "Theme" is the markup and code required to build an Engaging Networks Page Template (aka "Theme"). The Engaging Networks Page Templates are then used by Engaging Networks pages, loading the code and markup defined in them. Later on we'll discuss what a "Client Theme".
+A "Theme" is the markup and code required to build an Engaging Networks Page Template (aka "Theme"). The Engaging Networks Page Templates are then used by Engaging Networks pages, loading the code and markup defined in them. Later on we'll discuss what is a "Client Theme".
 
 ## What is "ENgrid Scripts"?
 
-We will start by discussing the ENgrid Scripts code base, as it is the core dependency that is a part of every ENgrid Client Theme. It contains two packages, one for styles ([@engrid-styles](https://www.npmjs.com/package/@4site/engrid-styles)) and one for scripts ([@engrid-scripts](https://www.npmjs.com/package/@4site/engrid-scripts)), and both are required to build an ENgrid theme. ENgrid Scipts is the code that all ENgrid clients share. Generally, if we do development on something that we think more than one client will benefit from, we do it in ENgrid Scripts so that can happen. Otherwise, we do it in the Client Theme so that only you theme is impacted.
+We will start by discussing the ENgrid Scripts code base, as it is the core dependency that is a part of every ENgrid Client Theme. It contains two packages, one for styles ([@engrid-styles](https://www.npmjs.com/package/@4site/engrid-styles)) and one for scripts ([@engrid-scripts](https://www.npmjs.com/package/@4site/engrid-scripts)), and both are required to build an ENgrid theme. ENgrid Scripts is the code that all ENgrid clients share. Generally, if we do development on something that we think more than one client will benefit from, we do it in ENgrid Scripts so that can happen. Otherwise, we do it in the Client Theme so that only you theme is impacted.
 
 ## What is a "Client Theme"?
 


### PR DESCRIPTION
After confirming with the author of the `bryans-tampermonkey-scripts` repository that it is now private, I added a note to the documentation regarding this private access.

The "Variables Reference" topic contained a link to a deleted file. Commits [bd2236e2](https://github.com/4site-interactive-studios/engrid/commit/bd2236e298d8ab7adcabfe02e407c24d3cf92c25) (renaming `engrid-variables.scss to `custom-properties.scss`) and [08d388574](https://github.com/4site-interactive-studios/engrid/commit/08d3885745cb86e5ab5cf55ddad53853b62b2010) (merging all css custom properties in with their corresponding SCSS) confirmed the change. I have rewritten this section to point to the ENgrid styles source folder to ensure the styling information remains available.

"ENgrid Visualization" had a link pointing to an Email to Target page which was inactive. This [https://act.ran.org/page/55579/subscribe/1](https://act.ran.org/page/55579/subscribe/1)  link replaced the inactive page link. 

Note: Could you verify if this new link qualifies as an "Email to Target" page?

The new topic "4Site SOP" was added. I modified the header to match the project's standard title pattern (using YAML frontmatter) instead of the # H1 header provided in the original task. This ensures consistent rendering across all pages.

<img width="1073" height="421" alt="Captura de Tela 2026-01-30 às 09 32 14" src="https://github.com/user-attachments/assets/273a9bb5-7443-4098-8d68-dbc34942f58b" />

Although not explicitly requested in the task, I used Copilot to identify and fix various typos throughout the project.
