### PR TITLE
Multilingual Pages docs for page-language i18n

### DIFF
--- a/src/pages/docs/v2/engrid-core-functions.md
+++ b/src/pages/docs/v2/engrid-core-functions.md
@@ -112,6 +112,8 @@ ENGrid.t("a11y.errorSummary", { count: 2, messages: "First name. Email" });
 // Spanish page: "Hay 2 errores: First name. Email."
 ```
 
+`ENGrid.hasI18nKey(key)` checks whether a key is defined for the current page language, without counting the English fallback.
+
 See [Multilingual Pages](/docs/v2/multilingual-pages) for the full list of dictionary keys and how to override them with `window.EngridI18n`.
 
 ### Page Type Detection

--- a/src/pages/docs/v2/engrid-core-functions.md
+++ b/src/pages/docs/v2/engrid-core-functions.md
@@ -91,6 +91,28 @@ ENGrid.createHiddenInput("utm_source", "email_campaign");
 | `ENGrid.getPageCount()` | Returns total number of pages | `number \| null` |
 | `ENGrid.isThankYouPage()` | Checks if current page is the thank you page | `boolean` |
 | `ENGrid.getGiftProcess()` | Returns gift process status | `boolean \| null` |
+| `ENGrid.getPageLanguage()` | Returns the 2-letter page language from `pageJson.locale` (defaults to `"en"`) | `string` |
+
+### Page Language
+
+`ENGrid.getPageLanguage()` returns the first two characters of `pageJson.locale`, lowercased (`"es_US"` → `"es"`). When `pageJson` or the locale is unavailable, it returns `"en"`.
+
+```typescript
+if (ENGrid.getPageLanguage() === "es") {
+  // Spanish page logic
+}
+```
+
+### Translating UI Strings
+
+`ENGrid.t(key, replacements?)` looks up a string in ENgrid's built-in i18n dictionary for the current page language, falling back to English. Values in curly braces are interpolated from the `replacements` argument.
+
+```typescript
+ENGrid.t("a11y.errorSummary", { count: 2, messages: "First name. Email" });
+// Spanish page: "Hay 2 errores: First name. Email."
+```
+
+See [Multilingual Pages](/docs/v2/multilingual-pages) for the full list of dictionary keys and how to override them with `window.EngridI18n`.
 
 ### Page Type Detection
 

--- a/src/pages/docs/v2/form-field-enhancements.md
+++ b/src/pages/docs/v2/form-field-enhancements.md
@@ -337,6 +337,8 @@ The component includes defaults for all standard EN fields:
 
 ...and many more (over 30 fields covered).
 
+The built-in defaults follow the page language — on Spanish pages they are added in Spanish automatically (for example, "Street Address" becomes "Calle y número"). Placeholders you set via the `Placeholders` option are never translated. See [Multilingual Pages](/docs/v2/multilingual-pages) for details.
+
 ### Customizing Placeholders
 
 Override defaults globally via `window.EngridOptions`:

--- a/src/pages/docs/v2/multilingual-pages.md
+++ b/src/pages/docs/v2/multilingual-pages.md
@@ -48,8 +48,21 @@ ENgrid ships a small dictionary for the UI strings it generates. When the page l
 | `translateFields.select` | Select | Seleccione |
 | `translateFields.recipientTo` | To: | Para: |
 | `a11y.errorSummary` | There are {count} errors: {messages}. | Hay {count} errores: {messages}. |
+| `placeholders.firstName` | First Name | Nombre |
+| `placeholders.lastName` | Last Name | Apellidos |
+| `placeholders.emailAddress` | Email Address | Correo electrónico |
+| `placeholders.phoneNumber` | Phone Number | Teléfono |
+| `placeholders.phoneNumberOptional` | Phone Number (Optional) | Teléfono (opcional) |
+| `placeholders.country` | Country | País |
+| `placeholders.address1` | Street Address | Calle y número |
+| `placeholders.address2` | Apt., Ste., Bldg. | Depto., Piso, Edif. |
+| `placeholders.city` | City | Ciudad |
+| `placeholders.region` | Region | Provincia/Estado |
+| `placeholders.postcode` | ZIP Code | Código Postal |
 
 Values in curly braces (like `{count}` or `{label}`) are placeholders that ENgrid fills in at runtime.
+
+The `placeholders.*` keys drive the [input placeholders](/docs/v2/form-field-enhancements#input-placeholders) ENgrid adds when the `add-input-placeholders` body data attribute is enabled. Placeholders you set yourself with the `Placeholders` option always win — ENgrid never translates your custom strings.
 
 ## Customizing Strings with `EngridI18n`
 
@@ -107,6 +120,8 @@ Country-based translations (like the built-in Brazilian Portuguese, German, Fren
 If the selected country has no defined translations, the page language stays in place. For example, on a Spanish page, a donor who selects Brazil gets the Portuguese address labels, and any field not covered by the Portuguese set remains in Spanish.
 
 State field labels and "Select…" placeholder options also follow the page language (for example, "Select State" becomes "Seleccione Estado" on Spanish pages), while state and province names themselves are not translated.
+
+When a field's placeholder mirrors its label, the placeholder is translated along with the label. A placeholder with custom hint text of its own is left untouched, so you keep full control over format hints.
 
 You can extend or replace the language layer with the existing `EngridTranslate` global, using the 2-letter language code as the key:
 

--- a/src/pages/docs/v2/multilingual-pages.md
+++ b/src/pages/docs/v2/multilingual-pages.md
@@ -1,0 +1,121 @@
+---
+title: Multilingual Pages
+description: How ENgrid detects the page language and translates its built-in UI strings and form fields, with built-in English and Spanish support.
+---
+
+## Overview
+
+ENgrid detects the language of the current Engaging Networks page and uses it to translate the UI strings it generates (like the "Remember Me" checkbox or validation announcements) and, when you use the TranslateFields component, your form field labels and placeholders.
+
+English (`en`) and Spanish (`es`) are supported out of the box. You can override any built-in string, or add support for more languages, with the `EngridI18n` global.
+
+## Page Language Detection
+
+`ENGrid.getPageLanguage()` returns the current page language as a 2-letter code: the first two characters of `pageJson.locale`, lowercased.
+
+| `pageJson.locale` | `ENGrid.getPageLanguage()` |
+| ----------------- | -------------------------- |
+| `en_US` | `en` |
+| `es_ES` | `es` |
+| `es-MX` | `es` |
+| (not set) | `en` |
+
+```typescript
+if (ENGrid.getPageLanguage() === "es") {
+  // Spanish page logic
+}
+```
+
+{% callout title="You should know!" %}
+When `pageJson` or `pageJson.locale` is not available, the page language defaults to `en`.
+{% /callout %}
+
+## Built-in Translations
+
+ENgrid ships a small dictionary for the UI strings it generates. When the page language is Spanish, these strings are used automatically — you don't need to configure anything.
+
+| Key | English | Spanish |
+| --- | ------- | ------- |
+| `rememberMe.label` | Remember Me | Recuérdame |
+| `rememberMe.clearLabel` | (clear autofill) | (borrar autocompletado) |
+| `rememberMe.tooltip` | Check "{label}" to complete forms on this device faster... | Marca "{label}" para completar los formularios en este dispositivo más rápido... |
+| `rememberMe.iframeTitle` | Remember Me iframe | iframe de Recuérdame |
+| `translateFields.state` | State | Estado |
+| `translateFields.stateGeneric` | Province / State | Provincia/Estado |
+| `translateFields.stateRegion` | State/Region | Estado/Región |
+| `translateFields.provinceTerritory` | Province / Territory | Provincia/Territorio |
+| `translateFields.selectState` | Select State | Seleccione Estado |
+| `translateFields.select` | Select | Seleccione |
+| `translateFields.recipientTo` | To: | Para: |
+| `a11y.errorSummary` | There are {count} errors: {messages}. | Hay {count} errores: {messages}. |
+
+Values in curly braces (like `{count}` or `{label}`) are placeholders that ENgrid fills in at runtime.
+
+## Customizing Strings with `EngridI18n`
+
+Use the `window.EngridI18n` global to override any dictionary string or to add a new language. Your strings are merged over the defaults key-by-key, per language — you only need to provide the strings you want to change.
+
+```javascript
+window.EngridI18n = {
+  es: {
+    // Override a built-in Spanish string
+    "rememberMe.label": "Acuérdate de mí",
+  },
+  fr: {
+    // Add a new language
+    "rememberMe.label": "Se souvenir de moi",
+    "rememberMe.clearLabel": "(effacer le remplissage automatique)",
+  },
+};
+```
+
+Resolution order for every string: the current page language → English → the key itself. If a string is missing in the page language, the English default is used, so partial dictionaries are safe.
+
+## Translating Form Fields by Page Language
+
+When the TranslateFields component is enabled (`TranslateFields: true`, on by default), the page language is used as the **base translation layer** for supporter field labels and placeholders. It is applied on page load and again every time the country field changes.
+
+Spanish pages get these field translations out of the box:
+
+| Field | Spanish Label |
+| ----- | ------------- |
+| `supporter.firstName` | Nombre |
+| `supporter.lastName` | Apellidos |
+| `supporter.emailAddress` | Correo electrónico |
+| `supporter.phoneNumber` | Teléfono |
+| `supporter.address1` | Dirección |
+| `supporter.address2` | Complemento |
+| `supporter.postcode` | Código Postal |
+| `supporter.city` | Ciudad |
+| `supporter.region` | Provincia/Estado |
+| `supporter.country` | País |
+
+### How Language and Country Translations Combine
+
+Country-based translations (like the built-in Brazilian Portuguese, German, French, and Dutch sets) still work and are layered **on top of** the page language:
+
+1. Fields are reset to the labels from your Engaging Networks page builder.
+2. The page language layer is applied.
+3. The selected country layer is applied on top, winning per field.
+
+If the selected country has no defined translations, the page language stays in place. For example, on a Spanish page, a donor who selects Brazil gets the Portuguese address labels, and any field not covered by the Portuguese set remains in Spanish.
+
+State field labels and "Select…" placeholder options also follow the page language (for example, "Select State" becomes "Seleccione Estado" on Spanish pages), while state and province names themselves are not translated.
+
+You can extend or replace the language layer with the existing `EngridTranslate` global, using the 2-letter language code as the key:
+
+```javascript
+window.EngridTranslate = {
+  es: [
+    { field: "supporter.firstName", translation: "Tu nombre" },
+  ],
+};
+```
+
+## Remember Me on Multilingual Pages
+
+The Remember Me checkbox label, "(clear autofill)" link, and info tooltip automatically use the dictionary strings for the page language. If you set `rememberMeLabel` or `fieldClearLabel` in the component options, your values always win over the dictionary.
+
+## Validation Error Announcements
+
+The summary announced to screen readers when multiple validation errors are present ("There are X errors: …") also follows the page language ("Hay X errores: …" in Spanish).

--- a/src/pages/docs/v2/multilingual-pages.md
+++ b/src/pages/docs/v2/multilingual-pages.md
@@ -38,7 +38,7 @@ ENgrid ships a small dictionary for the UI strings it generates. When the page l
 | --- | ------- | ------- |
 | `rememberMe.label` | Remember Me | Recuérdame |
 | `rememberMe.clearLabel` | (clear autofill) | (borrar autocompletado) |
-| `rememberMe.tooltip` | Check "{label}" to complete forms on this device faster... | Marca "{label}" para completar los formularios en este dispositivo más rápido... |
+| `rememberMe.tooltip` | Check “{label}” to complete forms on this device faster... | Marque “{label}” para completar los formularios en este dispositivo más rápido... |
 | `rememberMe.iframeTitle` | Remember Me iframe | iframe de Recuérdame |
 | `translateFields.state` | State | Estado |
 | `translateFields.stateGeneric` | Province / State | Provincia/Estado |
@@ -71,6 +71,12 @@ window.EngridI18n = {
 
 Resolution order for every string: the current page language → English → the key itself. If a string is missing in the page language, the English default is used, so partial dictionaries are safe.
 
+You can check whether a key is defined for the current page language (not counting the English fallback) with `ENGrid.hasI18nKey(key)`:
+
+```typescript
+ENGrid.hasI18nKey("translateFields.recipientTo"); // true on "es" pages, false on "fr" unless you add it
+```
+
 ## Translating Form Fields by Page Language
 
 When the TranslateFields component is enabled (`TranslateFields: true`, on by default), the page language is used as the **base translation layer** for supporter field labels and placeholders. It is applied on page load and again every time the country field changes.
@@ -84,7 +90,7 @@ Spanish pages get these field translations out of the box:
 | `supporter.emailAddress` | Correo electrónico |
 | `supporter.phoneNumber` | Teléfono |
 | `supporter.address1` | Dirección |
-| `supporter.address2` | Complemento |
+| `supporter.address2` | Departamento/Piso |
 | `supporter.postcode` | Código Postal |
 | `supporter.city` | Ciudad |
 | `supporter.region` | Provincia/Estado |

--- a/src/pages/docs/v2/multilingual-pages.md
+++ b/src/pages/docs/v2/multilingual-pages.md
@@ -53,6 +53,7 @@ ENgrid ships a small dictionary for the UI strings it generates. When the page l
 | `placeholders.emailAddress` | Email Address | Correo electrónico |
 | `placeholders.phoneNumber` | Phone Number | Teléfono |
 | `placeholders.phoneNumberOptional` | Phone Number (Optional) | Teléfono (opcional) |
+| `placeholders.phoneNumber2Optional` | 000-000-0000 (Optional) | 000-000-0000 (opcional) |
 | `placeholders.country` | Country | País |
 | `placeholders.address1` | Street Address | Calle y número |
 | `placeholders.address2` | Apt., Ste., Bldg. | Depto., Piso, Edif. |

--- a/src/pages/docs/v2/remember-me.md
+++ b/src/pages/docs/v2/remember-me.md
@@ -78,6 +78,17 @@ Control where the Remember Me checkbox and clear link appear:
 | `fieldClearSelectorTarget` | CSS selector for where to insert the clear link | `'label[for="en__field_supporter_firstName"]'` |
 | `fieldClearSelectorTargetLocation` | Where to insert relative to target (`"before"` or `"after"`) | `"before"` |
 
+### Label and Localization Options
+
+Control the text of the Remember Me checkbox and clear link:
+
+| Property | Description | Default |
+| -------- | ----------- | ------- |
+| `rememberMeLabel` | Text of the Remember Me checkbox label | Localized `"Remember Me"` (e.g. `"Recuérdame"` on Spanish pages) |
+| `fieldClearLabel` | Text of the clear autofill link | Localized `"(clear autofill)"` (e.g. `"(borrar autocompletado)"` on Spanish pages) |
+
+The defaults, the info tooltip, and the iframe title follow the page language automatically. Values you set here always win over the built-in dictionary. See [Multilingual Pages](/docs/v2/multilingual-pages) for details.
+
 ## Complete Configuration Example
 
 ```javascript


### PR DESCRIPTION
Documentation for the page-language i18n feature shipping in engrid (4site-interactive-studios/engrid#427).

## Changes
- **New page: `/docs/v2/multilingual-pages`** — page language detection (`ENGrid.getPageLanguage()`), the built-in en/es dictionary keys, overriding strings via `window.EngridI18n`, TranslateFields language layering (language base + country override), Spanish field defaults, and the RememberMe/a11y localized strings.
- **ENGrid Core Functions** — added `getPageLanguage()` to the Page State table and new subsections for page language and `ENGrid.t()`.
- **Remember Me** — documented the previously undocumented `rememberMeLabel`/`fieldClearLabel` options and their new language-aware defaults.

## Verification
- `npm run build` (next build) passes; `/docs/v2/multilingual-pages` is generated as a static route.